### PR TITLE
added ruby-qt4-uitools dependency for ubuntu 14.04

### DIFF
--- a/rock.osdeps-ruby19
+++ b/rock.osdeps-ruby19
@@ -3,7 +3,7 @@ qtruby:
         kde-base/kdebindings-ruby
     arch: kdebindings-qtruby
     ubuntu:
-        '14.04': ruby-qt4
+        '14.04': [ruby-qt4, ruby-qt4-uitools]
         default:
             gem: qtbindings
             osdep: [qt4, qt4-opengl, qt-designer]


### PR DESCRIPTION
I needed to install this package in order to get qt4 bindings working in a start script using bundles and vizkit
