### PR TITLE
fix Qt bindings

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -80,6 +80,10 @@ qt4-opengl:
     gentoo: qt-opengl 
     fedora: qt-devel
 
+qt4-webkit:
+    debian,ubuntu: libqtwebkit-dev
+    fedora: qt-devel
+
 qt-designer:
     debian,ubuntu: qt4-designer
     gentoo: x11-libs/qt-gui

--- a/rock.osdeps-ruby19
+++ b/rock.osdeps-ruby19
@@ -3,13 +3,13 @@ qtruby:
         kde-base/kdebindings-ruby
     arch: kdebindings-qtruby
     ubuntu:
-        '14.04': [ruby-qt4, ruby-qt4-uitools]
+        '14.04': [ruby-qt4, ruby-qt4-uitools, ruby-qt4-webkit]
         default:
             gem: qtbindings
-            osdep: [qt4, qt4-opengl, qt-designer]
+            osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
     default:
         gem: qtbindings
-        osdep: [qt4, qt4-opengl, qt-designer]
+        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
 
 rake-compiler: 
     debian,ubuntu:

--- a/rock.osdeps-ruby20
+++ b/rock.osdeps-ruby20
@@ -4,6 +4,6 @@ qtruby:
     arch: kdebindings-qtruby
     default:
         gem: qtbindings
-        osdep: qt4
+        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
 
 rake-compiler: gem

--- a/rock.osdeps-ruby21
+++ b/rock.osdeps-ruby21
@@ -3,10 +3,10 @@ qtruby:
         kde-base/kdebindings-ruby
     arch: kdebindings-qtruby
     debian:
-        sid: ruby-qt4
+        sid: [ruby-qt4, ruby-qt4-uitools, ruby-qt4-webkit]
     default,ubuntu:
         gem: qtbindings
-        osdep: qt4
+        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
 
 rake-compiler: gem
 


### PR DESCRIPTION
Rock needs the Qt bindings for both OpenGL, UITools and WebKit, so
make sure that they either get built when we install the qtbindings
gem, or that they are installed when using the Debian packages.
