### PR TITLE
fix flavor handling for non-implicit flavors

### DIFF
--- a/rock/flavor_manager.rb
+++ b/rock/flavor_manager.rb
@@ -170,12 +170,12 @@ module Rock
 
                 if current_flavor.implicit?
                     in_a_flavor = flavors.values.inject(Set.new) do |pkgs, other_flavor| 
-                        pkgs | other_flavor.default_packages[pkg_set]
+                        pkgs | other_flavor.default_packages[pkg_set.name]
                     end
                     default_packages = (meta.packages.map(&:name).to_set - in_a_flavor) |
-                        current_flavor.default_packages[pkg_set]
+                        current_flavor.default_packages[pkg_set.name]
                 else
-                    default_packages = current_flavor.default_packages[pkg_set]
+                    default_packages = current_flavor.default_packages[pkg_set.name]
                 end
                 default_packages -= current_flavor.removed_packages
                 default_packages = default_packages.to_set


### PR DESCRIPTION
FlavorManager#finalize was wrongly accessing default_packages with
the package set object instead of with the package set name.

It fixes the stable and next flavors.
