### PR TITLE
ROCK_BUNDLE_PATH should only define super folder of bundles

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -89,7 +89,6 @@ end
 # So far, bundles are mostly Ruby packages
 def bundle_package(*args, &block)
     ruby_package(*args) do |pkg|
-        Autoproj.env_add_path 'ROCK_BUNDLE_PATH', pkg.srcdir
         if block_given?
             pkg.instance_eval(&block)
         end


### PR DESCRIPTION
ROCK_BUNDLE_PATH should only contain higher-level folder where bundles can be found as subfolders. It should not contain the bundle folders themselves.