### PR TITLE
added rock-webapp ruby package

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -1,10 +1,14 @@
 # IMPORTANT: new packages must be added at the top of this file
 # They must NEVER be added to other files
 
-
 cmake_package 'tools/class_loader' do |pkg|
     pkg.depends_on 'base/console_bridge'
     pkg.depends_on 'poco'
     pkg.define "BUILD_SHARED_LIBS", "ON"
     pkg.define 'CMAKE_BUILD_TYPE', "Release"
+end
+
+cmake_package 'gui/rock_webapp'
+ruby_package 'tools/rest_api' do |pkg|
+    Autoproj.env_set 'ROCK_WEBAPP', File.join(pkg.prefix, 'share', 'rest_api')
 end

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -125,3 +125,10 @@ cucumber: gem
 
 poco:
     debian,ubuntu: libpoco-dev
+
+faye-websocket: gem
+rack-cors: gem
+thin: gem
+grape: gem
+sprockets: gem
+


### PR DESCRIPTION
rock-webapp provides a way to interface with rock using a REST api. This
is e.g. for providing web based clients for rock installations.