### PR TITLE
class_loader: mark as stable

### DIFF
--- a/manifests/tools/class_loader.xml
+++ b/manifests/tools/class_loader.xml
@@ -5,5 +5,6 @@
   <url>http://ros.org/wiki/class_loader</url>
   <depend package="base/console_bridge" />
   <depend package="poco" />
+  <tags>stable</tags>
 </package>
 


### PR DESCRIPTION
Otherwise the debug version of libpoco is slected with might be not installed