### PR TITLE
build class_loader in release mode

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -6,4 +6,5 @@ cmake_package 'tools/class_loader' do |pkg|
     pkg.depends_on 'base/console_bridge'
     pkg.depends_on 'poco'
     pkg.define "BUILD_SHARED_LIBS", "ON"
+    pkg.define 'CMAKE_BUILD_TYPE', "Release"
 end


### PR DESCRIPTION
This workarounds an Ubuntu bug on Ubuntu 14.10, in which the symlinks
to the debug version of pocoFoundation are present but not the actual
libs.

The other option would be to install the -dbg package.