### PR TITLE
add the thor osdep

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -125,3 +125,6 @@ cucumber: gem
 
 poco:
     debian,ubuntu: libpoco-dev
+
+thor:
+    debian,ubuntu: ruby-thor


### PR DESCRIPTION
Thor is a [CLI-building tool](whatisthor.com). I've started to use it for some tooling instead of OptionParser because it feels a lot cleaner. You really build an API and tell thor how to expose it to the command line, instead of having a big toplevel script.