### PR TITLE
Declar opencv to be unavailable as System dependency on Ubuntu 12.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -107,7 +107,10 @@ qt-designer:
     macos-brew: qt4
 
 opencv:
-    debian, ubuntu: libopencv-dev
+    debian: libopencv-dev
+    ubuntu:
+        '12.04': nonexistent
+        default: libopencv-dev
     gentoo: media-libs/opencv
     fedora: opencv-devel
     arch,manjarolinux: opencv


### PR DESCRIPTION
Set ubuntu to be non-existent on ubuntu 12.04. the packlaged version is too old for some libraries (e.g. aruco). 'external/opencv' should be taken as fallback.

See rock-core/rock-package_set#44
