### PR TITLE
tune testing support

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -125,6 +125,18 @@ in_flavor 'master', 'stable' do
             Autobuild.update_environment srcdir
             Autoproj.env_set 'ORBInitRef',"NameService=corbaname::127.0.0.1"
         end
+
+        def pkg.invoke_rake(target_name = rake_setup_task)
+            if test_utility.enabled?
+                Autobuild.invoke_make_parallel(self) do |*make_options|
+                    make_options = make_options.
+                        map { |opt| opt.gsub(',', ';') }
+                    test_target = "setup:orogen_all[1,#{Autobuild::Orogen.transports.join(" ")},'#{make_options.join("' '")}']"
+                    super(test_target)
+                end
+            end
+            super
+        end
     end
 
     ruby_package 'tools/pocolog'

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -127,6 +127,7 @@ in_flavor 'master', 'stable' do
         end
 
         def pkg.invoke_rake(target_name = rake_setup_task)
+            super
             if test_utility.enabled?
                 Autobuild.invoke_make_parallel(self) do |*make_options|
                     make_options = make_options.
@@ -135,7 +136,6 @@ in_flavor 'master', 'stable' do
                     super(test_target)
                 end
             end
-            super
         end
     end
 

--- a/overrides.rb
+++ b/overrides.rb
@@ -97,6 +97,13 @@ only_on 'debian' do
   end  
 end
 
+# Manage the Rock standard flag for tests
+Autoproj.post_import do |pkg|
+   if pkg.kind_of?(Autobuild::CMake)
+      pkg.define "ROCK_TEST_ENABLED", pkg.test_utility.enabled?
+   end
+end
+
 # enabling the compile_commands feature for cmake based projects. allows for
 # example usage of semantic c/c++ completion tools.
 #

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -143,6 +143,7 @@ jpeg:
 bundler: gem
 cucumber: gem
 
+
 poco:
     debian,ubuntu: libpoco-dev
     macos-brew: poco
@@ -167,4 +168,7 @@ qtruby:
         osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
     gentoo:
         kde-base/kdebindings-ruby
+
+fakefs: gem
+flexmock: gem
 


### PR DESCRIPTION
This controls ROCK_TEST_ENABLED (from the Rock cmake macros) based on whether
the underlying package has tests enabled or not, and makes sure that we build
orocos.rb's test oroGen components during the build phase if tests are enabled
for it (and that we do so with the appropriate -j)