### PR TITLE
rock.core package set affected by renaming image_processing 

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -164,12 +164,15 @@ in_flavor 'master', 'stable' do
     cmake_package 'perception/jpeg_conversion' do |pkg|
         pkg.define "RUBY_EXECUTABLE", Autoproj::CmdLine.ruby_executable
     end
+    metapackage 'image_processing/jpeg_conversion', 'perception/jpeg_conversion'
+
     cmake_package 'perception/frame_helper' do |pkg|
         if Autoproj.manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", user_config('rtt_target')
         end
         pkg.define "RUBY_EXECUTABLE", Autoproj::CmdLine.ruby_executable
     end
+    metapackage 'image_processing/frame_helper', 'perception/frame_helper'
 
     ##### Graphical User Interface related packages 
     cmake_package 'gui/rock_widget_collection' do |pkg|

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -161,10 +161,10 @@ in_flavor 'master', 'stable' do
         Autoproj.env_add_path 'OROGEN_PLUGIN_PATH', File.join(pkg.prefix, "share", "orogen", "plugins" )
     end
 
-    cmake_package 'image_processing/jpeg_conversion' do |pkg|
+    cmake_package 'perception/jpeg_conversion' do |pkg|
         pkg.define "RUBY_EXECUTABLE", Autoproj::CmdLine.ruby_executable
     end
-    cmake_package 'image_processing/frame_helper' do |pkg|
+    cmake_package 'perception/frame_helper' do |pkg|
         if Autoproj.manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", user_config('rtt_target')
         end

--- a/source.yml
+++ b/source.yml
@@ -43,8 +43,8 @@ version_control:
       github: rock-core/drivers-orogen-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH
 
-    - image_processing/.*:
-      github: rock-core/image_processing-$PACKAGE_BASENAME
+    - perception/.*:
+      github: rock-core/perception-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH
 
     - tools/autoproj:


### PR DESCRIPTION
It aims to rename image_processing to perception (core packages affected). Discussed in the rock-dev mailing list email.

It should be done in conjunction with https://github.com/rock-core/rock-package_set/pull/53