### PR TITLE
Update Arch Linux osdeps

### DIFF
--- a/06osdeps_from_source.autobuild
+++ b/06osdeps_from_source.autobuild
@@ -14,5 +14,9 @@ in_flavor 'master', 'stable' do
     end
     Autoproj.add_osdeps_overrides 'opencv', :package => 'external/opencv'
     remove_from_default 'external/opencv'
+
+    cmake_package 'tools/poco'
+    Autoproj.add_osdeps_overrides 'poco', :package => 'tools/poco'
+    remove_from_default 'tools/poco'
 end
 

--- a/manifests/tools/poco.xml
+++ b/manifests/tools/poco.xml
@@ -1,0 +1,9 @@
+<package>
+  <description brief="C++ class libraries for network-centric, portable applications">
+    Modern, powerful open source C++ class libraries for building network- and internet-based applications that run on desktop, server, mobile and embedded systems.
+  </description>
+  <author>Günter Obiltschnig/guenter@pocoproject.org</author>
+  <license>Boost Software License - Version 1.0</license>
+  <url>http://www.pocoproject.org/</url>
+  <tags></tags>
+</package>

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -63,15 +63,18 @@ rice:
 qwt5:
     debian,ubuntu: libqwt5-qt4-dev
     fedora,opensuse: qwt-devel
+    arch: qwt5
 
 vtk-qt4:
     debian,ubuntu: libvtk5-qt4-dev
     fedora,opensuse: vtk-devel
+    arch: vtk
 
 freeglut3:
     debian,ubuntu: freeglut3-dev
     fedora,opensuse: freeglut-devel
     macos-brew: freeglut
+    arch: freeglut
 
 osg:
     debian,ubuntu: libopenscenegraph-dev
@@ -96,6 +99,7 @@ qt4-opengl:
     gentoo: qt-opengl
     fedora,opensuse: qt-devel
     macos-brew: qt4
+    arch: qt4
 
 qt4-webkit:
     debian,ubuntu: libqtwebkit-dev
@@ -124,6 +128,7 @@ jpeg:
     fedora: libjpeg-turbo-devel
     macos-brew: jpeg
     opensuse: libjpeg-devel
+    arch: libjpeg-turbo
 
 bundler: gem
 cucumber: gem
@@ -151,5 +156,4 @@ qtruby:
         osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
     gentoo:
         kde-base/kdebindings-ruby
-    arch: kdebindings-qtruby
 

--- a/source.yml
+++ b/source.yml
@@ -84,6 +84,11 @@ version_control:
       url: http://downloads.sourceforge.net/project/opencvlibrary/opencv-unix/2.4.9/opencv-2.4.9.zip
       update_cached_file: false
       archive_dir: opencv-2.4.9
+    - tools/poco:
+      type: archive
+      url: https://github.com/pocoproject/poco/archive/poco-1.6.0-release.zip
+      update_cached_file: false
+      archive_dir: poco-poco-1.6.0-release
 
     - tools/class_loader:
       github: ros/class_loader


### PR DESCRIPTION
The osdeps for Arch Linux are partially outdated. This PR gets it up and running on Arch again.