### PR TITLE
osdep: add minitest

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -171,4 +171,4 @@ qtruby:
 
 fakefs: gem
 flexmock: gem
-
+minitest: gem


### PR DESCRIPTION
The minitest bundled with Ruby is really old and not compatible with some (all
?) of the minitest-based test suites in the rock.core Ruby packages