### PR TITLE
Use in Ubuntu the repository version of the ruby package flexmock

### DIFF
--- a/rock.osdeps-ruby19
+++ b/rock.osdeps-ruby19
@@ -3,3 +3,5 @@ rake-compiler:
         gem: rake-compiler<0.9.0
     default:
         gem: rake-compiler
+flexmock:
+    gem: "flexmock<2.0"


### PR DESCRIPTION
This at least solved the issue for my installation.