### PR TITLE
added ubuntu 15.10 changes

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -11,7 +11,10 @@ avahi:
     macos-port: avahi
 
 sigc:
-    debian,ubuntu: [libsigc++-2.0-0c2a, libsigc++-2.0-dev]
+    debian: [libsigc++-2.0-0c2a, libsigc++-2.0-dev]
+    ubuntu:
+      '12.04,14.04,14.10,15.04': [libsigc++-2.0-0c2a, libsigc++-2.0-dev]
+      default: [libsigc++-2.0-0v5, libsigc++-2.0-dev]
     gentoo: dev-libs/libsigc++
     fedora: libsigc++-devel
     arch,manjarolinux: libsigc++


### PR DESCRIPTION
15.10 is currently in beta phase, only added definition for latest 2 LTS Versions (12.04, 14.04) and Versions after the last LTS (14.10 adn 15.04) for backward compability.

The default in the new (and future os package)
