### PR TITLE
set pastel version

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -34,7 +34,7 @@ binding_of_caller:
     gem: binding_of_caller
 
 activesupport:
-    gem: activesupport
+    gem: activesupport <= 4.2.5.1
 
 eigen3:
     debian, ubuntu: libeigen3-dev

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -194,5 +194,7 @@ tty-table: gem
 tty-pager: gem
 tty-platform: gem
 tty-screen: gem
-pastel: gem
+pastel:
+    gem:
+        - pastel<0.6
 


### PR DESCRIPTION
Not defining it specificly results in following error:

/usr/lib/ruby/2.1.0/rubygems/specification.rb:2064:in `raise_if_conflicts': Unable to activate tty-0.3.2, because pastel-0.6.0 conflicts with pastel (~> 0.5.1) (Gem::LoadError)
