### PR TITLE
install os package of activesupport which should be compatible with t…

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -34,7 +34,10 @@ binding_of_caller:
     gem: binding_of_caller
 
 activesupport:
-    gem: activesupport <= 4.2.5.1
+  ubuntu: ruby-activesupport
+  debian: ruby-activesupport
+  default:
+    gem: activesupport
 
 eigen3:
     debian, ubuntu: libeigen3-dev
@@ -162,6 +165,7 @@ faye-websocket: gem
 rack-cors: gem
 thin: gem
 grape: gem
+
 sprockets: gem
 
 thor:


### PR DESCRIPTION
…he current os ruby version

the current gem requires ruby 2.2
