### PR TITLE
use OS packaged version if the hoe gem

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -60,7 +60,12 @@ webgen:
         - cmdparse<3.0
 coderay: gem
 kramdown: gem
-hoe: gem
+hoe: 
+    ubuntu:
+      '14.04,14.10,15.04': ruby-hoe
+      default: gem
+    default: gem
+
 yard: gem
 hoe-yard: gem
 rice:

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -64,6 +64,9 @@ hoe:
     ubuntu:
       '14.04,14.10,15.04': ruby-hoe
       default: gem
+    debian:
+      'jessie': ruby-hoe
+      default: gem
     default: gem
 
 yard: gem


### PR DESCRIPTION
Hoe gem fails recently because of version conflicts with rake:

on master:
in directory /data/jenkins/workspace/workspace/rock-basic/Flavor/master/node/Ubuntu_15.04/dev/base/scripts
    cannot load the Hoe gem. Distribution is disabled

on stable:
'utilrb' cannot be build -- loading gem failed: Unable to activate hoe-3.14.2, because rake-11.1.1 conflicts with rake (< 11.0, >= 0.8)

using the packages version solves the issue