### PR TITLE
adds grape_logging gem dependency (logging for the REST API)

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -165,6 +165,7 @@ faye-websocket: gem
 rack-cors: gem
 thin: gem
 grape: gem
+grape_logging: gem
 
 sprockets: gem
 


### PR DESCRIPTION
Needed by the pull request on https://github.com/rock-core/tools-rest_api that references this PR