### PR TITLE
added base-logging cmake package

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -1,6 +1,8 @@
 # IMPORTANT: new packages must be added at the top of this file
 # They must NEVER be added to other files
 
+cmake_package 'base/logging'
+
 cmake_package 'tools/class_loader' do |pkg|
     pkg.depends_on 'base/console_bridge'
     pkg.depends_on 'poco'


### PR DESCRIPTION
adds cmake_package base/logging (prepares removal of these herders from base_types)

@2maz Can you try to transfer the repo from my accout to rock-core (i'm lacking admin rights on rock-core, cannot do it myself, you should have rights by now, or i'll try to transfer it to you first)