### PR TITLE
remove the constraint on pastel

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -198,9 +198,7 @@ tty-table: gem
 tty-pager: gem
 tty-platform: gem
 tty-screen: gem
-pastel:
-    gem:
-        - pastel<0.6
+pastel: gem
 
 rgl: gem
 autorespawn: gem


### PR DESCRIPTION
It's obsolete, the cli-using packages (mainly autoproj) are now using
the latest.