### PR TITLE
extract the Eigen ruby bindings in a separate package

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -13,3 +13,5 @@ cmake_package 'gui/rock_webapp'
 ruby_package 'tools/rest_api' do |pkg|
     Autoproj.env_set 'ROCK_WEBAPP', File.join(pkg.prefix, 'share', 'rest_api')
 end
+
+ruby_package 'base/ruby_eigen'


### PR DESCRIPTION
This will allow releasing them as a gem, thus improving the integration
with both ruby-doc and travis-ci for this package and for other pure-ruby
packages that depend on it (but not on base/types)

Having it installed at the same time than base/types should be
harmless (it will pick one or the other depending on the setup of
RUBYLIB). The bindings should be removed from base/types once this
is merged.

The library has had its test suite extended, which uncovered a few
bugs. Documentation has been improved dramatically by documenting
the C++ extension.
