### PR TITLE
Added configure option, if everything should be build with c++11

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -12,7 +12,6 @@ ignore(/\.sw?$/)
 # Ignore the numerous backup files
 ignore(/~$/)
 
-
 # Ruby 1.8 is completly outdated, if you modify this, take respect to the addition checks below against 1.9 
 if defined?(RUBY_VERSION) && (RUBY_VERSION =~ /^1\.8\./)
     Autoproj.error "Ruby 1.8 is not supported by Rock anymore"
@@ -35,16 +34,16 @@ Rock.flavors.define 'stable'
 Rock.flavors.alias 'stable', 'next'
 Rock.flavors.define 'master', :implicit => true
 
-def add_compiler_flag(varName, value)
-    curVal = Autobuild.env_value(varName)
-    if(curVal)
-        curVal = curVal.join(' ')
-        if(!curVal.include?(value))
-            value.concat(' ')
-            value.concat(curVal)
+def add_compiler_flag(var_name, value)
+    cur_val = Autobuild.env_value var_name
+    if cur_val
+        cur_val = cur_val.join ' '
+        if !cur_val.include? value
+            value.concat ' '
+            value.concat cur_val
         end
     end
-    Autobuild.env_set(varName, value) 
+    Autobuild.env_set var_name, value
 end
 
 configuration_option('ROCK_SELECTED_FLAVOR', 'string',
@@ -64,8 +63,8 @@ Autoproj.configuration_option 'cxx11', 'boolean',
 :default => 'yes',
 :doc => ["Compile with Cxx11 ? [yes/no]"]
 
-if (Autoproj.user_config('cxx11')) then
-    add_compiler_flag('CXXFLAGS', "-std=c++11")
+if Autoproj.user_config 'cxx11'
+    add_compiler_flag 'CXXFLAGS', "-std=c++11"
 end
 
 #This check is needed because the overrides file will override the FLAVOR selection.

--- a/init.rb
+++ b/init.rb
@@ -35,6 +35,18 @@ Rock.flavors.define 'stable'
 Rock.flavors.alias 'stable', 'next'
 Rock.flavors.define 'master', :implicit => true
 
+def add_compiler_flag(varName, value)
+    curVal = Autobuild.env_value(varName)
+    if(curVal)
+        curVal = curVal.join(' ')
+        if(!curVal.include?(value))
+            value.concat(' ')
+            value.concat(curVal)
+        end
+    end
+    Autobuild.env_set(varName, value) 
+end
+
 configuration_option('ROCK_SELECTED_FLAVOR', 'string',
     :default => 'stable',
     :possible_values => ['stable', 'master'],
@@ -47,6 +59,14 @@ Rock.flavors.select_current_flavor_by_name(
     ENV['ROCK_FORCE_FLAVOR'] || Autoproj.config.get('ROCK_SELECTED_FLAVOR'))
 
 current_flavor = Rock.flavors.current_flavor
+
+Autoproj.configuration_option 'cxx11', 'boolean',
+:default => 'yes',
+:doc => ["Compile with Cxx11 ? [yes/no]"]
+
+if (Autoproj.user_config('cxx11')) then
+    add_compiler_flag('CXXFLAGS', "-std=c++11")
+end
 
 #This check is needed because the overrides file will override the FLAVOR selection.
 #Furthermore a selection != stable can cause a inconsistent layout (cause by in_flavor system in the package_sets)

--- a/overrides.rb
+++ b/overrides.rb
@@ -114,4 +114,11 @@ Autoproj.post_import do |pkg|
    end
 end
 
+if Autoproj.user_config 'cxx11'
+    Autoproj.post_import do |pkg|
+        if pkg.kind_of?(Autobuild::CMake)
+            pkg.define "ROCK_USE_CXX11", "TRUE"
+        end
+    end
+end
 


### PR DESCRIPTION
Note, as env_add creates a : between all elements, I needed a new helper method.
This should go into autoproj itself in the future.
