### PR TITLE
modify to be compatible with both autoproj v1 and v2

### DIFF
--- a/rock/flavor_manager.rb
+++ b/rock/flavor_manager.rb
@@ -49,11 +49,7 @@ module Rock
             end
 
             if flavor_def.implicit?
-                if Autoproj.respond_to?(:workspace) # 2.0
-                    pkg_set = Autoproj.manifest.find_package_definition(pkg).package_set
-                else
-                    pkg_set = Autoproj.manifest.find_package(pkg).package_set
-                end
+                pkg_set = Autoproj.manifest.find_package_definition(pkg).package_set
                 if package_sets.include?(pkg_set)
                     !flavor_def.removed?(pkg)
                 else

--- a/rock/flavor_manager.rb
+++ b/rock/flavor_manager.rb
@@ -109,11 +109,13 @@ module Rock
 
             flavor = current_flavor
 
-            current_packages = Autoproj.manifest.packages.keys
+            current_packages = Autoproj.manifest.each_package_definition.to_set
             InFlavorContext.new(flavor.name, flavors, options[:strict]).
                 instance_eval(&block)
 
-            new_packages = Autoproj.manifest.packages.keys - current_packages
+            new_packages = Autoproj.manifest.each_package_definition.
+                find_all { |pkg| !current_packages.include?(pkg) }.
+                map(&:name)
             add_packages_to_flavors Autoproj.current_package_set, flavors => new_packages
         end
 
@@ -176,12 +178,13 @@ module Rock
         def finalize
             package_sets.each do |pkg_set|
                 meta = Autoproj.manifest.metapackages[pkg_set.name]
+                meta_package_names = meta.each_package.inject(Set.new) { |s, p| s << p.name }
 
                 if current_flavor.implicit?
                     in_a_flavor = flavors.values.inject(Set.new) do |pkgs, other_flavor| 
                         pkgs | other_flavor.default_packages[pkg_set.name]
                     end
-                    default_packages = (meta.packages.map(&:name).to_set - in_a_flavor) |
+                    default_packages = (meta_package_names - in_a_flavor) |
                         current_flavor.default_packages[pkg_set.name]
                 else
                     default_packages = current_flavor.default_packages[pkg_set.name]
@@ -189,8 +192,9 @@ module Rock
                 default_packages -= current_flavor.removed_packages
                 default_packages = default_packages.to_set
                 current_flavor.default_packages[pkg_set.name] = default_packages
-                meta.packages.delete_if do |pkg|
-                    !default_packages.include?(pkg.name)
+
+                (meta_package_names - default_packages).each do |pkg_name|
+                    meta.remove(pkg_name)
                 end
             end
         end

--- a/rock/in_flavor_context.rb
+++ b/rock/in_flavor_context.rb
@@ -22,16 +22,14 @@ module Rock
                 package_name = args.first
 
                 manifest = ::Autoproj.manifest
-                package_set = ::Autoproj.current_package_set
+                if existing_package = manifest.find_package_definition(package_name)
+                    package_set = existing_package.package_set
+                else
+                    package_set = ::Autoproj.current_package_set
+                end
                 if ::Autoproj.respond_to?(:workspace) # autoproj v2
-                    if existing_package = manifest.find_package_definition(package_name)
-                        package_set = existing_package.package_set
-                    end
                     vcs = manifest.importer_definition_for(package_name, package_set: package_set, require_existing: false)
                 else
-                    if existing_package = manifest.find_package(package_name)
-                        package_set = existing_package.package_set
-                    end
                     vcs = manifest.importer_definition_for(package_name, package_set)
                 end
 


### PR DESCRIPTION
some APIs changed in autoproj v2 (that's why it's a major version bump after all). This makes sure that the flavor code is compatible both with the old and new APIs.