### PR TITLE
control C++11 and castxml selection

### DIFF
--- a/defaults.osdeps
+++ b/defaults.osdeps
@@ -1,0 +1,29 @@
+# This file defines fake osdep entries to check whether certain features should
+# be enabled on certain OSes by default
+#
+# 'nonexistent' => no
+# 'ignore' => yes
+
+
+# Check whether the default C++ loader should be castxml (ignore) or gccxml
+# (nonexistent)
+default_castxml:
+    ubuntu:
+        '12.04,12.10,13.04,13.10,14.04,14.10,15.04': nonexistent
+        default: ignore
+    debian:
+        testing,unstable: ignore
+        default: nonexistent
+    default: nonexistent
+
+# Check whether the default C++ standard should be C++11 (ignore) or C++98
+# (nonexistent)
+default_cxx11:
+    ubuntu:
+        '12.04,12.10,13.04,13.10,14.04,14.10,15.04,15.10': nonexistent
+        default: ignore
+    debian:
+        testing,unstable: ignore
+        default: nonexistent
+    default: nonexistent
+

--- a/init.rb
+++ b/init.rb
@@ -126,3 +126,4 @@ end
 if Autobuild.macos?
     Autobuild::Orogen.transports.delete("mqueue")
 end
+

--- a/overrides.rb
+++ b/overrides.rb
@@ -26,12 +26,18 @@ if !wrong_branch.empty?
     Autoproj.warn "  #{pkgs}"
 end
 
-require File.join(File.dirname(__FILE__), 'rock/git_hook')
-require File.join(File.dirname(__FILE__), 'rock/cmake_build_type')
-
 Autoproj.env_add_path 'ROCK_BUNDLE_PATH', File.join(Autobuild.prefix, 'share', 'rock')
 Autoproj.env_add_path 'ROCK_BUNDLE_PATH', File.join(Autoproj.root_dir, 'bundles')
 
+require File.join(__dir__, 'rock', 'cxx11')
+if Autoproj.respond_to?(:workspace) # autoproj 2.0
+    Rock.setup_cxx11_support(Autoproj.workspace.os_package_resolver, Autoproj.config)
+else
+    Rock.setup_cxx11_support(Autoproj.osdeps, Autoproj.config)
+end
+
+require File.join(__dir__, 'rock', 'git_hook')
+require File.join(__dir__, 'rock', 'cmake_build_type')
 Autoproj.manifest.each_autobuild_package do |pkg|
     case pkg.importer
     when Autobuild::Git
@@ -91,6 +97,8 @@ Autoproj.manifest.each_autobuild_package do |pkg|
         setup_package(pkg.name) do
             pkg.define 'ROCK_TEST_LOG_DIR', pkg.test_utility.source_dir
         end
+
+        pkg.define 'ROCK_USE_CXX11', Autoproj.config.get('cxx11')
     end
 end
 

--- a/rock/cxx11.rb
+++ b/rock/cxx11.rb
@@ -17,9 +17,6 @@ module Rock
         if !config.has_value_for?('castxml') && os_package_resolver.has?('default_castxml')
             config.set 'typelib_cxx_loader', 'castxml', true
         end
-        if !config.has_value_for?('cxx11') && os_package_resolver.has?('default_cxx11')
-            config.set 'cxx11', true, true
-        end
 
         # Trigger the choice for C++11 if there is one, and force castxml if it is the case
         if config.get('cxx11')

--- a/rock/cxx11.rb
+++ b/rock/cxx11.rb
@@ -16,10 +16,7 @@ module Rock
 
         if !config.has_value_for?('castxml') && os_package_resolver.has?('default_castxml')
             config.set 'typelib_cxx_loader', 'castxml', true
-        end
-
-        # Trigger the choice for C++11 if there is one, and force castxml if it is the case
-        if config.get('cxx11')
+        elsif config.get('cxx11')
             config.set 'typelib_cxx_loader', 'castxml'
         else
             config.set 'typelib_cxx_loader', 'gccxml'

--- a/rock/cxx11.rb
+++ b/rock/cxx11.rb
@@ -1,0 +1,32 @@
+module Rock
+    # Offer the C++11 option only on systems where we either can install castxml
+    # from the OS packages, or build it.
+    #
+    # But then, set it to true on OSes where it should. This is controlled by
+    # stub osdep entries in defaults.osdeps
+    def self.setup_cxx11_support(os_package_resolver, config)
+        if os_package_resolver.has?('libclang-castxml') || os_package_resolver.has?('castxml')
+            config.declare 'cxx11', 'boolean',
+                default: 'no',
+                doc: "whether C++11 should be enabled for Rock packages"
+        else
+            config.set 'typelib_cxx_loader', 'gccxml'
+            config.set 'cxx11', false
+        end
+
+        if !config.has_value_for?('castxml') && os_package_resolver.has?('default_castxml')
+            config.set 'typelib_cxx_loader', 'castxml', true
+        end
+        if !config.has_value_for?('cxx11') && os_package_resolver.has?('default_cxx11')
+            config.set 'cxx11', true, true
+        end
+
+        # Trigger the choice for C++11 if there is one, and force castxml if it is the case
+        if config.get('cxx11')
+            config.set 'typelib_cxx_loader', 'castxml'
+        else
+            config.set 'typelib_cxx_loader', 'gccxml'
+        end
+    end
+end
+


### PR DESCRIPTION
This commit enables C++11 unconditionally on 16.04,
enables castxml unconditionally on gcc5 OSes (15.10, 16.04)
disables them unconditionally on other (OSes where castxml
is not available), and offers a choice to the user for the rest.

Once the C++11 support is added to orogen, it should be added
to the overrides as well.

Depends on https://github.com/orocos-toolchain/autoproj/pull/24

This "competes" with 
- https://github.com/rock-core/package_set/pull/86
- https://github.com/rock-core/package_set/pull/85
- https://github.com/rock-core/base-cmake/pull/29
- https://github.com/orocos-toolchain/orogen/pull/80
