### PR TITLE
Set CMake flags in post_import phase

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -70,7 +70,9 @@ Autoproj.manifest.each_autobuild_package do |pkg|
             pkg.optional_dependencies.delete 'ocl'
         end
     when Autobuild::CMake
-        Rock.update_cmake_build_type_from_tags(pkg)
+        pkg.post_import do
+            Rock.update_cmake_build_type_from_tags(pkg)
+        end
         pkg.define "ROCK_TEST_ENABLED", pkg.test_utility.enabled?
         pkg.define "CMAKE_EXPORT_COMPILE_COMMANDS", "ON"
     end


### PR DESCRIPTION
It seems that `pkg.tags` is not set at the moment `Rock.update_cmake_build_type_from_tags(pkg)` is called.
I reverted this part to a cleaned up version before https://github.com/rock-core/package_set/pull/92