### PR TITLE
remove vtk-qt4 on 16.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -80,8 +80,8 @@ qwt5:
 
 vtk-qt4:
     ubuntu:
-      '16.04': [libvtk5-qt4-dev,libvtk5-dev]
-      default: libvtk5-qt4-dev
+      default: nonexistent
+      '14.04,14.10,15.04,15.10': libvtk5-qt4-dev
     debian:
       'wheezy,jessie': libvtk5-qt4-dev
       default: nonexistent


### PR DESCRIPTION
Extensive discussion:
    https://github.com/rock-core/rock-package_set/pull/129

Basically, the only user of this osdep on rock.core is
rock_widget_collection, and its support is disabled by default
(e.g. enabled virtually nowhere). Given that this conflicts
on 16.04 with dependencies needed by PCL, a much more needed
package, let's just remove vtk-qt4 on 16.04.