### PR TITLE
Fix rack to older version

### DIFF
--- a/rock.osdeps-ruby21
+++ b/rock.osdeps-ruby21
@@ -1,3 +1,15 @@
 
 rake-compiler: gem
 
+thin:
+    gem: 
+        - rack<1.6.5
+        - thin<=1.7.0
+sprockets:
+    gem: 
+        - rack<1.6.5
+        - sprockets<=3.6.1
+grape:
+    gem: 
+        - rack<1.6.5
+        - grape<=0.16.2


### PR DESCRIPTION
The current version of rack needs ruby version >= 2.2.2. So users of ruby2.1 need an older version of rack. (change copied from rock.osdeps-ruby20)