### PR TITLE
removed nonexistring osdep autotools for 16.04 LTS

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -69,7 +69,9 @@ rice:
     default:
         gem: rice
         # Note: autoconf is an osdep built-in autoproj
-        osdep: autotools
+        osdep:       
+            default: nonexistent
+            '14.04,14.10,15.04,15.10': autotools
 
 qwt5:
     debian,ubuntu: libqwt5-qt4-dev


### PR DESCRIPTION
I observed an odd behavior with autoproj2 and Ubuntu 16.04 bootstraps. In 16.04 release there is no corresponding osdep "autotools" anymore. The interesting thing is, that if one requires the osdep rice -> autotools osdep chain in multiple *.osdeps sources and it's blocked in one file with '#' lines, the error "package autotools is not available as an osdep" does not occur. But if the only source with rice -> autotools is from rock.core, autoproj update when bootstrapping is not possible with autoproj2 and Ubuntu 16.04