### PR TITLE
properly set QT_PLUGIN_PATH and VIZKIT_PLUGIN_RUBY_PATH

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -77,9 +77,13 @@ Autoproj.manifest.each_autobuild_package do |pkg|
     when Autobuild::CMake
         pkg.post_import do
             Rock.update_cmake_build_type_from_tags(pkg)
+            if File.directory?(File.join(pkg.srcdir, 'viz'))
+                pkg.env_add_path 'VIZKIT_PLUGIN_RUBY_PATH', File.join(pkg.prefix, 'lib')
+            end
         end
         pkg.define "ROCK_TEST_ENABLED", pkg.test_utility.enabled?
         pkg.define "CMAKE_EXPORT_COMPILE_COMMANDS", "ON"
+        pkg.env_add_path 'QT_PLUGIN_PATH', File.join(pkg.prefix, 'lib', 'qt')
         setup_package(pkg.name) do
             pkg.define 'ROCK_TEST_LOG_DIR', pkg.test_utility.source_dir
         end


### PR DESCRIPTION
QT_PLUGIN_PATH will be filtered out by autoproj if it does not exist.
For the vizkit plugin case, we only add it when there is a 'viz'
directory, which I believe is fair.