### PR TITLE
remove manual branch override since the overrides in source.yml already take care of that

### DIFF
--- a/01import_orocos_toolchain.autobuild
+++ b/01import_orocos_toolchain.autobuild
@@ -59,21 +59,4 @@ move_package 'log4cpp', 'tools'
 move_package 'rtt_typelib', 'tools'
 Autoproj.manifest.moved_packages.delete('tools/metaruby')
 
-def override_branches(branch)
-    only_in_flavor branch do
-        setup_package 'ocl' do |pkg|
-            pkg.importer.branch = branch
-        end
-        setup_package 'log4cpp' do |pkg|
-            pkg.importer.branch = branch
-        end
-        setup_package 'rtt' do |pkg|
-            pkg.importer.branch = branch
-        end
-    end
-end
-
-override_branches "master"
-override_branches "stable"
-
 


### PR DESCRIPTION
it was breaking the ability to override the branch further in other
package sets and/or the main buildconf