### PR TITLE
change os defaults of debian to futureproof version

### DIFF
--- a/defaults.osdeps
+++ b/defaults.osdeps
@@ -12,8 +12,8 @@ default_castxml:
         '12.04,12.10,13.04,13.10,14.04,14.10,15.04': nonexistent
         default: ignore
     debian:
-        testing,unstable: ignore
-        default: nonexistent
+        squeeze,wheezy,jessie: nonexistent
+        default: ignore
     default: nonexistent
 
 # Check whether the default C++ standard should be C++11 (ignore) or C++98
@@ -23,7 +23,7 @@ default_cxx11:
         '12.04,12.10,13.04,13.10,14.04,14.10,15.04,15.10': nonexistent
         default: ignore
     debian:
-        testing,unstable: ignore
-        default: nonexistent
+        squeeze,wheezy,jessie: nonexistent
+        default: ignore
     default: nonexistent
 


### PR DESCRIPTION
Also,

"Autoproj.workspace.os_package_resolver.has?('default_castxml')" failed for debian testing.

could be that this is because /etc/os-release does not mention "testing"

```
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```