### PR TITLE
osdeps: add ruby-dev as dependency of all gems that have a C extension

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -34,6 +34,7 @@ websocket-gem:
 
 binding_of_caller:
     gem: binding_of_caller
+    osdep: ruby-dev
 
 activesupport:
   ubuntu: ruby-activesupport
@@ -69,7 +70,9 @@ rice:
     default:
         gem: rice
         # Note: autoconf is an osdep built-in autoproj
-        osdep: autotools
+        osdep:
+        - autotools
+        - ruby-dev
 
 qwt5:
     debian,ubuntu: libqwt5-qt4-dev
@@ -170,7 +173,10 @@ poco:
 
 faye-websocket: gem
 rack-cors: gem
-thin: gem
+thin:
+    gem: thin
+    osdep: ruby-dev
+
 grape: gem
 grape_logging: gem
 
@@ -186,7 +192,7 @@ thor:
 qtruby:
     default:
         gem: qtbindings
-        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit]
+        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev]
     gentoo:
         kde-base/kdebindings-ruby
 
@@ -201,6 +207,7 @@ concurrent-ruby:
     gem:
     - concurrent-ruby
     - concurrent-ruby-ext
+    osdep: ruby-dev
 rb-readline: gem
 
 hooks: gem


### PR DESCRIPTION
This was originally installed because autoproj depended on utilrb which had a C extension. It's not the case anymore, and in any case we should make sure that the dependencies are set properly