### PR TITLE
Add the dependency of the GTest framework

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -224,8 +224,13 @@ rgl: gem
 autorespawn: gem
 timecop: gem
 
-libgtest-dev:
+google-test:
     debian,ubuntu: libgtest-dev
-
 google-mock:
     debian,ubuntu: google-mock
+
+# For backward compatibility with the previous definition in the 'rock' package
+# set
+libgtest-dev:
+    osdeps: google-test
+

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -223,3 +223,9 @@ pastel: gem
 rgl: gem
 autorespawn: gem
 timecop: gem
+
+libgtest-dev:
+    debian,ubuntu: libgtest-dev
+
+google-mock:
+    debian,ubuntu: google-mock


### PR DESCRIPTION
With https://github.com/rock-core/drivers-iodrivers_base/pull/20, iodrivers_base test suite would become dependent on GTest (only for the tests). This moves the gtest osdeps from rock to rock.core.