### PR TITLE
fix webapp path

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -13,5 +13,5 @@ end
 
 cmake_package 'gui/rock_webapp'
 ruby_package 'tools/rest_api' do |pkg|
-    Autoproj.env_set 'ROCK_WEBAPP', File.join(pkg.prefix, 'share', 'rest_api')
+    Autoproj.env_set 'ROCK_WEBAPP', File.join(Autobuild.prefix, 'share', 'rest_api')
 end


### PR DESCRIPTION
RubyPackage#prefix  changed from pointing to install folder to package location in autoproj 2

So now this uses the global install folder. 

This is also more "correct", because this is a plugin path which is populated by other packages. I think it should not rely on the prefix settings of the rest api package.