### PR TITLE
use the 0.3.8 release for class_loader

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -82,6 +82,7 @@ version_control:
     - tools/class_loader:
       github: ros/class_loader
       branch: indigo-devel
+      tag: 0.3.8
 
 overrides:
     - ^(orogen|typelib|rtt|utilrb|utilmm|rtt_typelib|tools/metaruby)$:


### PR DESCRIPTION
- the tip of indigo_devel does not build right now
- 0.3.8 is the last release of the 0.3.x branch, which is
  what we've been using so far
- 1.0.0 has been released, but I'd rather propose a PR that switches to 1.0.0 later,
  to give time for testing.