### PR TITLE
Make sure that make_options contain useful input

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -143,7 +143,13 @@ in_flavor 'master', 'stable' do
                 Autobuild.invoke_make_parallel(self) do |*make_options|
                     make_options = make_options.
                         map { |opt| opt.gsub(',', ';') }
-                    test_target = "setup:orogen_all[1,#{Autobuild::Orogen.transports.join(" ")},'#{make_options.join("' '")}']"
+                    test_options = [1]
+                    test_options << Autobuild::Orogen.transports.join(" ")
+                    make_options = make_options.join("' '")
+                    if make_options =~ /[a-zA-Z0-9]/
+                        test_options << make_options
+                    end
+                    test_target = "setup:orogen_all[#{test_options.join(',')}]"
                     super(test_target)
                 end
             end


### PR DESCRIPTION
An encountered error case was make_options = "''" while testing orocos.rb with Travis