### PR TITLE
constrain hoe version because newest (3.19) causes installation failures

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -63,7 +63,9 @@ webgen:
         - cmdparse<3.0
 coderay: gem
 kramdown: gem
-hoe: gem
+hoe: 
+    gem:
+        - hoe=3.18.1
 yard: gem
 hoe-yard: gem
 rice:


### PR DESCRIPTION
New rock bootstrap causes the following instllation error on `base/scripts`:

```
2019-10-30 11:58:44 +0100: running
    /usr/bin/ruby2.5 -S rake default
in directory /home/artemis/rock/base/scripts
DEPRECATED: Please switch readme to hash format for urls.
  Only defining 'home' url.
  This will be removed on or after 2020-10-28.
WARN: cannot load the Hoe gem, or Hoe fails. Publishing tasks are disabled
WARN: error message is: no implicit conversion of String into Integer
rake aborted!
Don't know how to build task 'default' (See the list of available tasks with `rake --tasks`)
/home/artemis/rock/localgems/ruby/2.5.0/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
Exit: pid 28021 exit 1
```

Constraining `hoe` to an older version helps. Can this be confirmed from other installations? How should we deal with the problem?