### PR TITLE
handle orogen's --test option

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -72,6 +72,10 @@ Autoproj.manifest.each_autobuild_package do |pkg|
         if !Autoproj.config.get('USE_OCL')
             pkg.optional_dependencies.delete 'ocl'
         end
+
+        pkg.post_import do
+            pkg.orogen_options << "--test" if pkg.test_utility.enabled?
+        end
     end
 
     if pkg.kind_of?(Autobuild::Ruby)


### PR DESCRIPTION
Once upon a time, a few years ago, Matthias implemented namespace
support in orogen. The main goal was to allow to define components
in a 'test' namespace, which would be disabled by default and only
enabled with orogen's `--test` option.

This links the `--test` option with orogen's test facility to use
the capability.