### PR TITLE
set Syskit_DIR to syskit/cmake

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -124,10 +124,11 @@ in_flavor 'master', 'stable' do
     orogen_package 'base/orogen/std'
 
     ruby_package 'tools/syskit' do |pkg|
-        def pkg.update_environment
-            super
-            Autoproj.env_add_path 'ROBY_PLUGIN_PATH', File.join(srcdir, "lib", "syskit", "roby_app/register_plugin.rb")
-        end
+        pkg.env_add_path(
+            'ROBY_PLUGIN_PATH',
+            File.join(pkg.srcdir, 'lib', 'syskit', 'roby_app', 'register_plugin.rb')
+        )
+        pkg.env_set 'Syskit_DIR', File.join(pkg.srcdir, 'cmake')
     end
 
     ruby_package  'tools/orocos.rb' do |pkg|


### PR DESCRIPTION
I am adding CMake scripts to Syskit to simplify testing oroGen components using Syskit itself. This change is required so that the CMake module is picked up by CMake.