### PR TITLE
remove 'tools/rubigen' from the rock.core metapackage

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -28,6 +28,7 @@ in_flavor 'master', 'stable' do
         pkg.depends_on 'cucumber'
         pkg.rake_setup_task = nil
     end
+    remove_from_default 'tools/rubigen'
 
     bundle_package 'bundles/rock'
     cmake_package 'tools/pocolog_cpp'


### PR DESCRIPTION
It was needed only because of the code generation in tools/roby
and tools/syskit. This functionality now uses thor.