### PR TITLE
Only query user once for the python version and executable

### DIFF
--- a/rock/python.rb
+++ b/rock/python.rb
@@ -199,8 +199,8 @@ module Rock
                              bin: nil,
                              version: nil)
         bin, version = resolve_python(ws: ws, bin: bin, version: version)
-        ws.config.set('python_executable', bin)
-        ws.config.set('python_version', version)
+        ws.config.set('python_executable', bin, true)
+        ws.config.set('python_version', version, true)
 
         rewrite_python_shims(bin, ws.root_dir)
         [bin, version]


### PR DESCRIPTION
Otherwise the user gets asked redundantly for the python_executable when using Rock.activate_python_path