### PR TITLE
Use python venv for python setup

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -288,6 +288,10 @@ python3-msgpack:
     debian,ubuntu: python3-msgpack
     opensuse: python3-msgpack
 
+python3-venv:
+    debian,ubuntu: python3-venv
+    opensuse: python3-virtualenv
+
 cython3:
     debian, ubuntu: cython3
     opensuse: python3-Cython

--- a/test/python_test.rb
+++ b/test/python_test.rb
@@ -8,6 +8,7 @@ module Rock
         before do
             @pkg = Autobuild::Package.new
             @ws = ws_create
+            @ws.setup
             flexmock(@pkg)
             @pkg.prefix = "/tmp/install/foo/"
             @env = flexmock(base: Autobuild::Environment)
@@ -133,8 +134,7 @@ module Rock
             Rock.activate_python(ws: @ws)
             assert(@ws.config.has_value_for?('python_executable'))
             assert(@ws.config.has_value_for?('python_version'))
-
-            python_bin = File.join(@ws.root_dir, "install","bin","python")
+            python_bin = File.join(@ws.root_dir, ".python_venv","bin","python")
             assert(File.exist?(python_bin))
             python_version = Rock.get_python_version(python_bin)
             assert(python_version == @ws.config.get('python_version'))


### PR DESCRIPTION
Draft of a python venv integration:
@doudou do you have a suggestion on how to ensure availability of python3 osdeps, e.g., using ws.os_package_installer in rock-core's init.rb would require the osdeps files to be loaded already?