### PR TITLE
provide an alternate way to pass test configuration to Ruby packages

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -81,10 +81,12 @@ Autoproj.manifest.each_autobuild_package do |pkg|
     if pkg.kind_of?(Autobuild::Ruby)
         pkg.post_import do
             if pkg.test_utility.enabled?
-                pkg.depends_on 'minitest-junit'
-                pkg.rake_test_options <<
+                pkg.depends_on "minitest-junit"
+                pkg.rake_test_options.concat([
                     "TESTOPTS=--junit --junit-jenkins "\
-                    "--junit-filename=#{pkg.test_utility.source_dir}/report.junit.xml"
+                    "--junit-filename=#{pkg.test_utility.source_dir}/report.junit.xml",
+                    "RUBOCOP=1", "JUNIT=1", "REPORT_DIR=#{pkg.test_utility.source_dir}"
+                ])
             end
         end
     end

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -320,3 +320,6 @@ gem2deb:
 
 qemu:
     debian,ubuntu: [qemu-user-static, qemubuilder]
+
+rubocop: gem
+rubocop-rock: gem


### PR DESCRIPTION
So far, we have only been providing the raw command-line options
necessary to get JUnit reports for Ruby packages using minitest.
This has been pretty effective as it requires no changes to
the packages themselves.

However, it turns out that I'd like to add the possibility to run
linters, as well as handle more complex situations (like Syskit
or bundles, which do separate runs of multiple test suites). This
does not work with the current setup.

So, *in addition to the existing flags*, pass "semantic" flags
RUBOCOP, JUNIT and REPORT_DIR to allow specific packages to use
them and create their own configurations, more adapted to their
specific needs. This should have zero effect on existing packages
which will simply ignore the flags.