### PR TITLE
explicitly mark python-msgpack as nonexistent on 20.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -265,7 +265,9 @@ python-pexpect:
     opensuse: python-pexpect
 
 python-msgpack:
-    debian,ubuntu: python-msgpack
+    debian,ubuntu:
+        "16.04,18.04,18.10,19.04,19.10": python-msgpack
+        default: nonexistent
     opensuse: python-msgpack
 
 python3:


### PR DESCRIPTION
The package that depends on it (pocolog2msgpack) will have to
explicitly upgrade to the Python3 version. At least, until then,
Rock Core bootstraps fine (it is an optional dependency of
pocolog2msgpack)