### PR TITLE
Add conditional commit pinning for packages incompatible with 16.04

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -132,3 +132,10 @@ only_on 'debian' do
     end
 end
 
+if (Autoproj.workspace.operating_system[1] & ['16.04']).any?
+    repository = Autobuild::Package['base/cmake'].importer.repository
+    Autobuild::Package['base/cmake'].importer.relocate(repository, {commit: '63f49ee9cfc5db8ee87cc69f8f3cd3aa6cfc1e0f'})
+    repository = Autobuild::Package['typelib'].importer.repository
+    Autobuild::Package['typelib'].importer.relocate(repository, {commit: 'aa3bd70d2dacede3a5d7833104d79eff3f8550ac'})
+end
+


### PR DESCRIPTION
The current version of base/cmake and typelib are incompatible with ubuntu 16.04

I think it is not worth fixing it in the packages in themself as support of ubuntu 16.04 ends next year.

So think pinning these packages on 16.04 systems is good enough as a fix and development can move on without interference.