### PR TITLE
Add fallback shell detection to 04stable.autobuild for base/scripts

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -98,11 +98,7 @@ in_flavor 'master', 'stable' do
                 else Autoproj.shell_helpers?
                 end
 
-            unless shell = ENV['SHELL']
-                Autoproj.warn("SHELL Variable not set, using fallback detection")
-                shell ||= %x[ps -p $$ -ocomm= | xargs which].strip
-            end
-            if shell_helpers
+            if shell_helpers && shell=ENV['SHELL']
                 shell_kind = File.basename(shell)
                 if shell_kind =~ /^\w+$/
                     shell_file = File.join(pkg.srcdir, "shell", shell_kind)
@@ -119,6 +115,8 @@ in_flavor 'master', 'stable' do
                         end
                     end
                 end
+            elsif shell.nil?
+                Autoproj.error("Unable to detect shell type. Please set the SHELL environment variable.")
             end
         end
     end

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -99,6 +99,9 @@ in_flavor 'master', 'stable' do
                 end
 
             if shell_helpers && shell = ENV['SHELL']
+                if shell.nil?
+                    Autoproj.warn("SHELL Variable not set, using fallback detection")
+                    shell ||= %x[ps -p $$ -ocomm= | tr -d '\n']
                 shell_kind = File.basename(shell)
                 if shell_kind =~ /^\w+$/
                     shell_file = File.join(pkg.srcdir, "shell", shell_kind)

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -98,10 +98,11 @@ in_flavor 'master', 'stable' do
                 else Autoproj.shell_helpers?
                 end
 
-            if shell_helpers && shell = ENV['SHELL']
-                if shell.nil?
-                    Autoproj.warn("SHELL Variable not set, using fallback detection")
-                    shell ||= %x[ps -p $$ -ocomm= | tr -d '\n']
+            unless shell = ENV['SHELL']
+                Autoproj.warn("SHELL Variable not set, using fallback detection")
+                shell ||= %x[ps -p $$ -ocomm= | tr -d '\n']
+            end
+            if shell_helpers
                 shell_kind = File.basename(shell)
                 if shell_kind =~ /^\w+$/
                     shell_file = File.join(pkg.srcdir, "shell", shell_kind)

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -100,7 +100,7 @@ in_flavor 'master', 'stable' do
 
             unless shell = ENV['SHELL']
                 Autoproj.warn("SHELL Variable not set, using fallback detection")
-                shell ||= %x[ps -p $$ -ocomm= | tr -d '\n']
+                shell ||= %x[ps -p $$ -ocomm= | xargs which].strip
             end
             if shell_helpers
                 shell_kind = File.basename(shell)

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -98,7 +98,7 @@ in_flavor 'master', 'stable' do
                 else Autoproj.shell_helpers?
                 end
 
-            if shell_helpers && shell=ENV['SHELL']
+            if shell_helpers && (shell = ENV['SHELL'])
                 shell_kind = File.basename(shell)
                 if shell_kind =~ /^\w+$/
                     shell_file = File.join(pkg.srcdir, "shell", shell_kind)
@@ -116,7 +116,7 @@ in_flavor 'master', 'stable' do
                     end
                 end
             elsif shell.nil?
-                Autoproj.error("Unable to detect shell type. Please set the SHELL environment variable.")
+                Autoproj.error("Unable to detect shell type. Please set the SHELL environment variable or disable \nshell helpers altogether by setting the shell_helpers configuration variable to false.")
             end
         end
     end


### PR DESCRIPTION
In some use cases (especially in docker setups) the environment SHELL variable might not be set. This PR adds a fallback option, providing a stable alternative to acquire the shell type via a system call.