### PR TITLE
stick to rubocop 0.83

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -321,5 +321,7 @@ gem2deb:
 qemu:
     debian,ubuntu: [qemu-user-static, qemubuilder]
 
-rubocop: gem
+rubocop:
+    gem:
+        - rubocop=0.83.0
 rubocop-rock: gem


### PR DESCRIPTION
rubocop 0.84 has a bug that triggers on tools/roby. It's already
fixed, but it does not seem it's enough to trigger a quick release.

Reference: https://github.com/rubocop-hq/rubocop/pull/8010

Since it breaks CI, stick to 0.83 until a fixed version gets
released.