### PR TITLE
define the ruby2_keywords gem as an osdeps

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -335,3 +335,4 @@ rubocop:
     gem:
         - rubocop=0.83.0
 rubocop-rock: gem
+ruby2_keywords: gem


### PR DESCRIPTION
This defines ruby2_keywords for ruby < 2.7, which helps fixing an
incompatibility moving forward with the keyword arguments.

As Gabriel said, the Ruby devs really messed this up