### PR TITLE
Unify qwt5 osdep from rock-package_set

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -75,8 +75,11 @@ rice:
         - ruby-dev
 
 qwt5:
-    debian,ubuntu: libqwt5-qt4-dev
+    debian,ubuntu:
+        default: libqwt5-qt4-dev
+        '20.04': nonexistent
     fedora,opensuse: qwt-devel
+    darwin: qwt
     arch: qwt5
     macos-port: qwt
     gentoo: x11-libs/qwt


### PR DESCRIPTION
`WARN: osdeps definition for qwt5, previously defined in /home/user/rock/autoproj/remotes/rock.core/rock.osdeps overridden by /home/user/rock/autoproj/remotes/rock/rock.osdeps`

The qwt5 osdep is defined in mutiple package sets. I would suggest to consolidate it here and remove the definition from the rock package set.