### PR TITLE
Change port of qt4 repo keyserver

### DIFF
--- a/rock.osrepos
+++ b/rock.osrepos
@@ -3,5 +3,5 @@
         - type: repo
           repo: deb http://ppa.launchpad.net/rock-core/qt4/ubuntu focal main
         - type: key
-          keyserver: hkp://keyserver.ubuntu.com
+          keyserver: hkp://keyserver.ubuntu.com:80
           id: 63BBCC76C6D55B7DF2D65B2A78CB407D3E3D8F94


### PR DESCRIPTION
The standard hkp port 11371 is blocked for us. Port 80 works as an alternative, and I don't see any disadvantages, so this would be a helpful change.