### PR TITLE
Organize python osdeps in version specific files

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -255,56 +255,6 @@ ruby-backports:
 ruby-xmlrpc:
    gem: xmlrpc
 
-python:
-    debian,ubuntu: python-dev
-    opensuse: python-devel
-
-python-nose:
-    debian,ubuntu: python-nose
-    opensuse: python-nose
-
-python-pexpect:
-    debian,ubuntu: python-pexpect
-    opensuse: python-pexpect
-
-python-msgpack:
-    debian,ubuntu:
-        "16.04,18.04,18.10,19.04,19.10": python-msgpack
-        default: nonexistent
-    opensuse: python-msgpack
-
-python3:
-    debian,ubuntu: python3-dev
-    opensuse: python3-devel
-
-python3-pip:
-    debian,ubuntu: python3-pip
-    opensuse: python3-pip
-
-python3-nose:
-    debian,ubuntu: python3-nose
-    opensuse: python3-nose
-
-python3-pexpect:
-    debian,ubuntu: python3-pexpect
-    opensuse: python3-pexpect
-
-python3-msgpack:
-    debian,ubuntu: python3-msgpack
-    opensuse: python3-msgpack
-
-python3-distutils:
-    debian,ubuntu: python3-distutils
-    opensuse: python3-distutils-extra
-
-python3-setuptools:
-    debian,ubuntu: python3-setuptools
-    opensuse: python3-setuptools
-
-cython3:
-    debian, ubuntu: cython3
-    opensuse: python3-Cython
-
 tty-progressbar: gem
 
 apt-utils:

--- a/rock.osdeps-python2
+++ b/rock.osdeps-python2
@@ -1,0 +1,18 @@
+python:
+    debian,ubuntu: python-dev
+    opensuse: python-devel
+
+python-nose:
+    debian,ubuntu: python-nose
+    opensuse: python-nose
+
+python-pexpect:
+    debian,ubuntu: python-pexpect
+    opensuse: python-pexpect
+
+python-msgpack:
+    debian,ubuntu:
+        "16.04,18.04,18.10,19.04,19.10": python-msgpack
+        default: nonexistent
+    opensuse: python-msgpack
+

--- a/rock.osdeps-python3
+++ b/rock.osdeps-python3
@@ -1,0 +1,64 @@
+python:
+    debian,ubuntu: python3-dev
+    opensuse: python3-devel
+
+python-pip:
+    debian,ubuntu: python3-pip
+    opensuse: python3-pip
+
+python-nose:
+    debian,ubuntu: python3-nose
+    opensuse: python3-nose
+
+python-pexpect:
+    debian,ubuntu: python3-pexpect
+    opensuse: python3-pexpect
+
+python-msgpack:
+    debian,ubuntu: python3-msgpack
+    opensuse: python3-msgpack
+
+python-distutils:
+    debian,ubuntu: python3-distutils
+    opensuse: python3-distutils-extra
+
+python-setuptools:
+    debian,ubuntu: python3-setuptools
+    opensuse: python3-setuptools
+
+cython:
+    debian, ubuntu: cython3
+    opensuse: python3-Cython
+
+python3:
+    debian,ubuntu: python3-dev
+    opensuse: python3-devel
+
+python3-pip:
+    debian,ubuntu: python3-pip
+    opensuse: python3-pip
+
+python3-nose:
+    debian,ubuntu: python3-nose
+    opensuse: python3-nose
+
+python3-pexpect:
+    debian,ubuntu: python3-pexpect
+    opensuse: python3-pexpect
+
+python3-msgpack:
+    debian,ubuntu: python3-msgpack
+    opensuse: python3-msgpack
+
+python3-distutils:
+    debian,ubuntu: python3-distutils
+    opensuse: python3-distutils-extra
+
+python3-setuptools:
+    debian,ubuntu: python3-setuptools
+    opensuse: python3-setuptools
+
+cython3:
+    debian, ubuntu: cython3
+    opensuse: python3-Cython
+


### PR DESCRIPTION
To facilitate switching from 2 to 3 existing python-X definitions will point to corresponding python3 packages.