### PR TITLE
Update python default

### DIFF
--- a/rock/python.rb
+++ b/rock/python.rb
@@ -87,6 +87,7 @@ module Rock
                          version: ws.config.get('python_version',nil))
         finders = [
             lambda { Autobuild.programs['python'] },
+            lambda { `which python3`.strip() },
             lambda { `which python`.strip() }
         ]
 

--- a/rock/python.rb
+++ b/rock/python.rb
@@ -204,11 +204,13 @@ module Rock
                 "are you operating on a valid autoproj workspace?"
         end
 
-        File.open(File.join(shim_path, 'python'), 'w') do |io|
+        python_path = File.join(shim_path, 'python')
+        File.open(python_path, 'w') do |io|
             io.puts "#! /bin/sh"
             io.puts "exec #{python_executable} \"$@\""
         end
-        FileUtils.chmod 0755, File.join(shim_path, 'python')
+        FileUtils.chmod 0755, python_path
+        python_path
     end
 
     def self.rewrite_pip_shims(python_executable, root_dir)
@@ -219,12 +221,13 @@ module Rock
                 "#{shim_path} - "\
                 "are you operating on a valid autoproj workspace?"
         end
-
-        File.open(File.join(shim_path, 'pip'), 'w') do |io|
+        pip_path = File.join(shim_path, 'pip')
+        File.open(pip_path, 'w') do |io|
             io.puts "#! /bin/sh"
             io.puts "exec #{python_executable} -m pip \"$@\""
         end
-        FileUtils.chmod 0755, File.join(shim_path, 'pip')
+        FileUtils.chmod 0755, pip_path
+        pip_path
     end
 
     # Activate configuration for python in the autoproj configuration

--- a/test/python_test.rb
+++ b/test/python_test.rb
@@ -54,6 +54,12 @@ module Rock
             python_bin, version = Rock.find_python(ws: @ws, version: "<100.0" )
             assert(File.exist?(python_bin))
             assert(version =~ /[0-9]+\.[0-9]+/)
+
+            # Python3 has higher priority, so should be picked
+            python_path = `which python3`.strip()
+            if File.exists?(python_path)
+                assert(version =~ /3.[0-9]+/)
+            end
         end
 
         it "custom resolve python" do


### PR DESCRIPTION
This allows auto resolution to select python3 with priority, instead of defaulting to /usr/bin/python.

Per default /usr/bin/python might either point to python2 (Ubuntu 18.04) or does not exist (Ubuntu 20.04).