### PR TITLE
Add cython as python2 dependency for consistency reasons

### DIFF
--- a/rock.osdeps-python2
+++ b/rock.osdeps-python2
@@ -1,3 +1,7 @@
+cython:
+    debian, ubuntu: cython
+    opensuse: python-Cython
+
 python:
     debian,ubuntu: python-dev
     opensuse: python-devel


### PR DESCRIPTION
Moved osdeps definition from rock-package_set: https://github.com/rock-core/rock-package_set/pull/234