### PR TITLE
create tools/orogen-syskit_tests

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -6,6 +6,9 @@ remove_from_default 'tools/apaka-rock_patches'
 ruby_package 'tools/apaka'
 remove_from_default 'tools/apaka'
 
+orogen_package "tools/orogen_syskit_tests"
+remove_from_default "tools/orogen_syskit_tests"
+
 cmake_package 'tools/msgpack-c' do |pkg|
     pkg.define "MSGPACK_BUILD_TESTS", pkg.test_utility.enabled?
 end


### PR DESCRIPTION
This is a test-only package for the benefit of Syskit's test suite.

Syskit currently has no test that actually starts orogen-generated
components. This will provide it with what is necessary to write
some.