### PR TITLE
Qt4 C++ support in focal

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -30,3 +30,6 @@ cmake_package 'gui/rock_webapp'
 ruby_package 'tools/rest_api' do |pkg|
     pkg.env_set 'ROCK_WEBAPP', File.join(pkg.prefix, 'share', 'rest_api')
 end
+
+cmake_package "gui/osg_qt4"
+remove_from_default "gui/osg_qt4"

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -9,6 +9,7 @@ in_flavor 'master', 'stable' do
     ruby_package 'gui/vizkit'
 
     cmake_package 'gui/vizkit3d' do |pkg|
+        pkg.depends_on "gui/osg_qt4"
         if manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", Autoproj.config.get('rtt_target')
         end

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -112,6 +112,13 @@ osg:
     arch,manjarolinux: openscenegraph
     # opensuse: libOpenSceneGraph-devel available in repository Application:/Geo
 
+gui/osg_qt4:
+    default:
+        osdep: osg
+    ubuntu:
+        '16.04,18.04,18.10,19.04,19.10':
+            osdep: osg
+
 qt4:
     # QMake is needed for the CMake macro for Qt4
     debian,ubuntu: [libqt4-dev, qt4-qmake]

--- a/rock.osrepos
+++ b/rock.osrepos
@@ -1,0 +1,7 @@
+- ubuntu:
+    - focal:
+        - type: repo
+          repo: deb http://ppa.launchpad.net/rock-core/qt4/ubuntu focal main
+        - type: key
+          keyserver: hkp://keyserver.ubuntu.com:80
+          id: 63BBCC76C6D55B7DF2D65B2A78CB407D3E3D8F94


### PR DESCRIPTION
This PR adds the parts of the qt4_focal branch that are ready to merge, which is essentially the C++-related parts (qt4 packages and the qt4_osg plugin).

The ruby part (qtbindings) still requires a change in autoproj