### PR TITLE
Pin rice to <4.0.0

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -68,7 +68,7 @@ yard: gem
 hoe-yard: gem
 rice:
     default:
-        gem: rice
+        gem: rice<4.0.0
         # Note: autoconf is an osdep built-in autoproj
         osdep:
         - autotools


### PR DESCRIPTION
Due to the latest changes in rice, which requires updating ruby extensions and c++17 - I suggest to pin rice for the moment to <4.0.0.
https://github.com/jasonroelofs/rice/blob/master/CHANGELOG.md


