### PR TITLE
Remove pinning of ruby2_keywords

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -297,7 +297,7 @@ rubocop:
 rubocop-rock: gem
 ruby2_keywords:
     gem:
-        - ruby2_keywords=0.0.2
+        - ruby2_keywords
 
 ftpd:
   gem:


### PR DESCRIPTION
Explicit support for ruby >= 2.0.0 is provided https://github.com/ruby/ruby2_keywords/commit/6974495d294cd59b8c0dba78a26b391f25154050
Incompatibilities affecting ruby2.5 have been fixed (>= v0.0.4)
see https://github.com/ruby/ruby2_keywords/commit/d6d1775d793bcaf206af700120b0b4bd2dc3842d