### PR TITLE
install qtbindings from git on Ubuntu 20.04 and later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,0 @@
-gem "qtbindings", git: "https://github.com/rock-core/qtbindings"
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+gem "qtbindings", git: "https://github.com/rock-core/qtbindings"
+

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -200,8 +200,13 @@ thor:
     default: gem
 
 qtruby:
-    default:
-        gem: qtbindings
+    ubuntu:
+        "16.04,18.04":
+            gem: qtbindings
+        default:
+            gem:
+            - name: qtbindings
+              git: https://github.com/rock-core/qtbindings
         osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
     gentoo:
         kde-base/kdebindings-ruby


### PR DESCRIPTION
This needs https://github.com/rock-core/autoproj/pull/333 to be merged and released.