### PR TITLE
feat: allow configuring the test task for tools/orocos.rb

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -144,6 +144,7 @@ in_flavor 'master', 'stable' do
 
     ruby_package  'tools/orocos.rb' do |pkg|
         pkg.env_set 'ORBInitRef',"NameService=corbaname::127.0.0.1"
+        pkg.rake_test_task = Autoproj.config.get("orocosrb_test_target", "test")
         if pkg.test_utility.enabled? && Autobuild::Orogen.transports.include?('mqueue')
             pkg.env_set 'OROCOSRB_TEST_USE_MQUEUE', '1'
         end


### PR DESCRIPTION
The async tests are too flaky to be executed automatically, which
is why tests are completely disabled right now in our CI.

This will allow to at least run everything-but-async, which is
a lot better than nothing