### PR TITLE
Set github default protocol

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -24,7 +24,7 @@ end
 
 require 'autoproj/gitorious'
 if !Autoproj.has_source_handler? 'github'
-    Autoproj.gitorious_server_configuration('GITHUB', 'github.com', :http_url => 'https://github.com')
+    Autoproj.gitorious_server_configuration('GITHUB', 'github.com', default: 'http', :http_url => 'https://github.com')
 end
 
 require File.join(__dir__, 'rock/flavor_definition')


### PR DESCRIPTION
Github disabled the git protocol access, so http should be the default.