### PR TITLE
Add qwt for focal to qwt5 osdeps

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -77,7 +77,7 @@ rice:
 qwt5:
     debian,ubuntu:
         default: libqwt5-qt4-dev
-        '20.04': nonexistent
+        '20.04': libqwt-qt5-dev
     fedora,opensuse: qwt-devel
     darwin: qwt
     arch: qwt5


### PR DESCRIPTION
Indeed qwt5 for qt4 is `nonexistent` on ubuntu 20.04, which requires qt5.

However packages that require qwt on ubuntu 20.04 build fine with `libqwt-qt5-dev`

At first qwt5 did not seem to be the correct key, however since qwt is defined for fedora, opensuse and darwin as well I didn't open up a new entry.