### PR TITLE
Introduce build_visualization option

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -170,3 +170,14 @@ unless Autoproj.config.has_value_for?('syskit_use_bundles')
     Autoproj.config.set 'syskit_use_bundles', true, true
 end
 
+Autoproj.config.declare 'build_visualization', 'boolean',
+    default: true,
+    short_doc: 'Whether vizkit visualizaztion plugins in "viz" subfolders of packages should be built',
+    doc: ['Should the visualizations be built (viz subfolder of packages)?',
+        'This will also evaluate the manifest.xml in the viz subfolder of a package',
+        'and install them',
+        'These dependencies will appear as dependencies of the main package']
+
+unless Autoproj.config.has_value_for?('build_visualization')
+    Autoproj.config.set 'build_visualization', true, true
+end


### PR DESCRIPTION
In our Institute we had the use case to build the rock workspace without visualizations.
Also, we realized that the existing manifest.xml files in the viz subfolders are not evaluated at all, even though there is one in the official template. Was this a feature of autoproj that was possibly lost when going from autoproj v1 to v2?

This PR introduces a configuration option to select globally if the viz folders should be build and also uses the viz/manifest.xml files to be able not to install dependencies only needed for the visualization.

This PR is meant to start a discussion on how to handle this situation the best way, e.g. we were unsure if we should actually ask for the option or just have a documentation on how to disable it by setting the config option directly.