### PR TITLE
fix: restrict minitest to < 5.16

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -222,7 +222,9 @@ qtruby:
 
 fakefs: gem
 flexmock: gem
-minitest: gem
+minitest:
+    gem:
+        "minitest < 5.16"
 minitest-junit: gem
 rack-test: gem
 minitest-em-sync: gem


### PR DESCRIPTION
Minitest 5.16.x assumes that all exceptions can be constructed
with `.new(message)`. This is not the case of most custom exceptions,
like the ones we have in orocos.rb or syskit.

https://github.com/minitest/minitest/issues/921