### PR TITLE
Flavor qt5

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -45,12 +45,16 @@ Rock.flavors.define 'master', :implicit => true
 
 configuration_option('ROCK_SELECTED_FLAVOR', 'string',
     :default => 'master',
-    :possible_values => ['stable', 'master'],
+    :possible_values => ['stable', 'master', 'qt5'],
     :doc => [
         "Which flavor of Rock do you want to use ?",
-        "Stay with the default ('master') if you want to use Rock on the most recent",
-        "distributions (Ubuntu 16.04 and later). Use 'stable' only for ",
-        "now officially unsupported distributions (Ubuntu 14.04)"])
+        "Stay with the default ('master') if you want to use Rock on",
+        "distributions where qt4 support exists (Ubuntu 16.04 to 20.04).",
+        "Use 'qt5' on newer distributions (Ubuntu 21.04 and later) or",
+        "if you want to use qt5 on your qt5 supporting distribution",
+        "(Ubuntu 18.04 and later). The 'qt5' flavor is not as complete as",
+        "the 'master' flavor. Use 'stable' only for",
+        "long unsupported distributions (Ubuntu 14.04)"])
 
 if Rock.in_release? && !Autoproj.config.has_value_for?('ROCK_SELECTED_FLAVOR')
     Autoproj.config.set 'ROCK_SELECTED_FLAVOR', 'stable', true


### PR DESCRIPTION
There are now considerable numbers of feature/qt5 branches floating around, but it turns out that having rock packages that try to support both qt4 and qt5 versions at the same time is problematic.

* Their manifest.xml cannot express the "at least one of" qt4 or qt5 libraries needed.
* The package cannot require the qt4/qt5 version of another rock package, and the other rock package cannot have both a qt4 and qt5 version installed.
* The package needs to know if it is supposed to build qt4 or qt5 version of its libraries(granted, this can be done easily), at the same time adjusting its dependencies for the selected variant.
* At least for the packages, it would be beneficial to not have to use branches to distinguish between the two variants, keeping common code the same and only having to use ifdef or different source files for the qt bits.

Since this is basically creating a new fork of rock, maybe that could be selected through the existing flavor system(a configuration would probably work, too).

For the osdeps, the qt4 osdeps would be moved to a rock.osdeps-qt4 file, the qt5 osdeps would be added to rock.osdeps-qt5 and the workspace variable osdep_suffixes would be setup accord to the flavor. The qt osdeps would be used without a version marker, making it impossible to mix qt4 and qt5 in the same rock installation, and allowing the packages manifest.xml to properly reference the qt osdeps. Packages that do not support qt4 or qt5 would be conditionally added to the relevant flavor(s).

I want to add that there is also a possible solution that involves teaching autoproj to work with gentoo-style use-flags, that is, options to packages that determine what they build, that the packages can use to conditionally depend on osdeps and other packages, and that the packages can require from other packages. If you think this would mean an explosion in the search space for package combinations, you'd be right.

Please discuss.

@doudou @planthaber @annaborn