### PR TITLE
Make sure orogen_opaque_autogen works if separate prefixes are enabled

### DIFF
--- a/02master.autobuild
+++ b/02master.autobuild
@@ -27,7 +27,9 @@ in_flavor 'master' do
     end
     remove_from_default 'tools/oropy_bridge'
 
-    cmake_package 'tools/orogen_opaque_autogen'
+    cmake_package 'tools/orogen_opaque_autogen' do |pkg|
+        pkg.env_add_path 'OROGEN_PLUGIN_PATH', File.join(pkg.prefix, "share", "orogen", "plugins" )
+    end
     remove_from_default 'tools/orogen_opaque_autogen'
 end
 


### PR DESCRIPTION
Without this, slam/orogen/maps fails with `unknown statement 'opaque_autogen' (OroGen::ConfigError)` (when building with separate prefixes)