### PR TITLE
feat: add tools/runkit

### DIFF
--- a/02master.autobuild
+++ b/02master.autobuild
@@ -31,6 +31,11 @@ in_flavor 'master' do
         pkg.env_add_path 'OROGEN_PLUGIN_PATH', File.join(pkg.prefix, "share", "orogen", "plugins" )
     end
     remove_from_default 'tools/orogen_opaque_autogen'
+
+    ruby_package "tools/runkit"
+    remove_from_default "tools/runkit"
+    orogen_package "tools/orogen_runkit_tests"
+    remove_from_default "tools/orogen_runkit_tests"
 end
 
 add_packages_to_flavors 'master' => ['orogen', 'rtt', 'utilmm', 'utilrb', 'typelib', 'rtt_typelib', 'tools/metaruby', 'ocl', 'log4cpp']

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -222,9 +222,7 @@ qtruby:
 
 fakefs: gem
 flexmock: gem
-minitest:
-    gem:
-        "minitest < 5.16"
+minitest: gem
 minitest-junit: gem
 rack-test: gem
 minitest-em-sync: gem


### PR DESCRIPTION
It is a cleaned up, minimal fork or orocos.rb that is designed to support Syskit. tools/orogen_runkit_tests is a supporting package for runkit's test suite.