### PR TITLE
stick to hoe 3

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -65,7 +65,9 @@ webgen:
         - cmdparse<3.0
 coderay: gem
 kramdown: gem
-hoe: gem
+hoe:
+    gem:
+        - hoe<4.0
 yard: gem
 hoe-yard: gem
 rice:


### PR DESCRIPTION
base/scripts and gui/vizkit still use Hoe in their Rakefile, while most other packages have been migrated away from it. Seems that it's breaking now.