### PR TITLE
Feature/qt5mergable

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -33,3 +33,6 @@ end
 
 cmake_package "gui/osg_qt4"
 remove_from_default "gui/osg_qt4"
+
+cmake_package "gui/osg_qt5"
+remove_from_default "gui/osg_qt5"

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -211,6 +211,8 @@ in_flavor 'master', 'stable' do
         pkg.env_add_path 'QT_PLUGIN_PATH', File.join(pkg.prefix, "lib", "qt")
     end
 
+    cmake_package 'gui/qtpropertybrowser'
+
     ##### Base implementation for data acquisition
     cmake_package 'drivers/iodrivers_base'
     orogen_package 'drivers/orogen/iodrivers_base'

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -6,10 +6,17 @@ manifest = if Autoproj.respond_to?(:workspace)
 add_packages_to_flavors 'stable' => ['orogen', 'rtt', 'utilmm', 'utilrb', 'typelib', 'rtt_typelib', 'tools/metaruby', 'ocl', 'log4cpp']
 
 in_flavor 'master', 'stable' do
-    ruby_package 'gui/vizkit'
+    if Autoproj.config.get('QTVER') == '4'
+        ruby_package 'gui/vizkit'
+    end
 
     cmake_package 'gui/vizkit3d' do |pkg|
-        pkg.depends_on "gui/osg_qt4"
+        # gui/vizkit3d needs to do this in their manifest
+        if Autoproj.config.get('QTVER') == '4'
+            pkg.depends_on "gui/osg_qt4"
+        else
+            pkg.depends_on "gui/osg_qt5"
+        end
         if manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", Autoproj.config.get('rtt_target')
         end

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -6,8 +6,6 @@ manifest = if Autoproj.respond_to?(:workspace)
 add_packages_to_flavors 'stable' => ['orogen', 'rtt', 'utilmm', 'utilrb', 'typelib', 'rtt_typelib', 'tools/metaruby', 'ocl', 'log4cpp']
 
 in_flavor 'master', 'stable' do
-    ruby_package 'gui/vizkit'
-
     cmake_package 'gui/vizkit3d' do |pkg|
         pkg.depends_on "gui/osg_qt4"
         if manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target

--- a/overrides.rb
+++ b/overrides.rb
@@ -132,3 +132,13 @@ only_on 'debian' do
     end
 end
 
+# select feature/qt5 branches where appropriate
+if Autoproj.config.get('QTVER') == '5'
+    ["gui/vizkit3d","gui/rock_widget_collection","base/types"].each do |pkgname|
+        pkg = Autoproj.manifest.package_definition_by_name(pkgname)
+        # update the vcs information with our branch
+        pkg.vcs = pkg.vcs.update({branch: "feature/qt5"})
+        # recreate the importer with the new information
+        pkg.autobuild.importer = pkg.vcs.create_autobuild_importer
+    end
+end

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -125,6 +125,10 @@ gui/osg_qt4:
         '16.04,18.04,18.10,19.04,19.10':
             osdep: osg
 
+gui/osg_qt5:
+    ubuntu: nonexistent
+    gentoo: dev-games/openscenegraph-qt
+
 qt4:
     # QMake is needed for the CMake macro for Qt4
     debian,ubuntu: [libqt4-dev, qt4-qmake]

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -119,9 +119,9 @@ gui/osg_qt4:
         '16.04,18.04,18.10,19.04,19.10':
             osdep: osg
 
-qt4:
+qt5:
     # QMake is needed for the CMake macro for Qt4
-    debian,ubuntu: [libqt4-dev, qt4-qmake]
+    debian,ubuntu: [qt5-default]
     gentoo:
         - dev-qt/qtcore
         - dev-qt/qtgui
@@ -130,8 +130,8 @@ qt4:
     macos-port: qt4-mac
     arch,manjarolinux: qt4
 
-qt4-opengl:
-    debian,ubuntu: libqt4-opengl-dev
+qt5-opengl:
+    debian,ubuntu: libqt5opengl5-dev
     gentoo: dev-qt/qtopengl
     fedora,opensuse: qt-devel
     macos-brew: qt4

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -121,7 +121,7 @@ gui/osg_qt4:
 
 qt5:
     # QMake is needed for the CMake macro for Qt4
-    debian,ubuntu: [qt5-default]
+    debian,ubuntu: [qt5-default, qttools5-dev]
     gentoo:
         - dev-qt/qtcore
         - dev-qt/qtgui

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -199,18 +199,6 @@ thor:
         default: ruby-thor
     default: gem
 
-qtruby:
-    ubuntu:
-        "16.04,18.04":
-            gem: qtbindings
-        default:
-            gem:
-            - name: qtbindings
-              git: https://github.com/rock-core/qtbindings
-        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
-    gentoo:
-        kde-base/kdebindings-ruby
-
 fakefs: gem
 flexmock: gem
 minitest: gem

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -121,7 +121,10 @@ gui/osg_qt4:
 
 qt5:
     # QMake is needed for the CMake macro for Qt4
-    debian,ubuntu: [qt5-default, qttools5-dev]
+    debian: [qt5-default, qttools5-dev]
+    ubuntu:
+        '18.04,20.04': [qt5-default, qttools5-dev]
+        default: [qtbase5-dev, qtbase5-dev-tools, libqt5svg5-dev]
     gentoo:
         - dev-qt/qtcore
         - dev-qt/qtgui

--- a/source.yml
+++ b/source.yml
@@ -46,6 +46,10 @@ version_control:
     - gui/qtpropertybrowser:
       github: abhijitkundu/QtPropertyBrowser
 
+    - gui/osg_qt5:
+      github: rock-core/gui-osg_qt4
+      branch: feature/qt5
+
     - drivers/orogen/.*:
       github: rock-core/drivers-orogen-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH

--- a/source.yml
+++ b/source.yml
@@ -42,6 +42,10 @@ version_control:
     - gui/.*:
       github: rock-core/gui-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH
+    
+    - gui/qtpropertybrowser:
+      github: abhijitkundu/QtPropertyBrowser
+
     - drivers/orogen/.*:
       github: rock-core/drivers-orogen-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH


### PR DESCRIPTION
This PR merges the osdeps changes from the feature/qt5 branch into the master branch and then creates a configuration variable "QTVER" to set the qt version to be used by the packages that potentially link together possibly through use of vizkit3d. Finally, the configuration variable is used to setup vizkit3d to compile against the given qt version.