### PR TITLE
Feature/qt5only

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -33,3 +33,6 @@ end
 
 cmake_package "gui/osg_qt4"
 remove_from_default "gui/osg_qt4"
+
+cmake_package "gui/osg_qt5"
+remove_from_default "gui/osg_qt5"

--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -7,7 +7,7 @@ add_packages_to_flavors 'stable' => ['orogen', 'rtt', 'utilmm', 'utilrb', 'typel
 
 in_flavor 'master', 'stable' do
     cmake_package 'gui/vizkit3d' do |pkg|
-        pkg.depends_on "gui/osg_qt4"
+        pkg.depends_on "gui/osg_qt5"
         if manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", Autoproj.config.get('rtt_target')
         end

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -119,6 +119,10 @@ gui/osg_qt4:
         '16.04,18.04,18.10,19.04,19.10':
             osdep: osg
 
+gui/osg_qt5:
+    ubuntu: nonexistent
+    gentoo: dev-games/openscenegraph-qt
+
 qt5:
     # QMake is needed for the CMake macro for Qt4
     debian: [qt5-default, qttools5-dev]

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -158,6 +158,13 @@ qt-designer:
     macos-brew: qt4
     macos-port: qt4-mac
 
+qt5-designer:
+    debian,ubuntu: qttools5-dev-tools
+    gentoo: dev-qt/designer:5
+    fedora,opensuse: qt-devel
+    macos-brew: qt5
+    macos-port: qt5-mac
+
 opencv:
     debian: libopencv-dev
     ubuntu:

--- a/source.yml
+++ b/source.yml
@@ -46,6 +46,10 @@ version_control:
     - gui/qtpropertybrowser:
       github: abhijitkundu/QtPropertyBrowser
 
+    - gui/osg_qt5:
+      github: rock-core/gui-osg_qt4
+      branch: feature/qt5
+
     - drivers/orogen/.*:
       github: rock-core/drivers-orogen-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH


### PR DESCRIPTION
This adds qt5_designer and osg_qt5 and changes the hard-coded depend of vizkit3d to osg_qt5.

Different to my other PR, this does not add back qt4 and does not change branches of preexisting packages.

@planthaber , this should be uncontroversal enough to be merged onto feature/qt5