### PR TITLE
chore: use a "forked" gem for qtbindings instead of using git directly

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -215,9 +215,7 @@ qtruby:
         "16.04,18.04":
             gem: qtbindings
         default:
-            gem:
-            - name: qtbindings
-              git: https://github.com/rock-core/qtbindings
+            gem: rock-qtbindings
         osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
     gentoo:
         kde-base/kdebindings-ruby


### PR DESCRIPTION
This way we can use caching methods for it instead of having to use unreliable methods (like pre-building it in the CI docker containers)