### PR TITLE
feat: define the zstd-ruby gem

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -232,6 +232,9 @@ minitar: gem
 zstd:
     ubuntu: zstd
 
+zstd-ruby:
+    gem: zstd-ruby
+
 concurrent-ruby:
     gem:
     - concurrent-ruby


### PR DESCRIPTION
syskit log archiving features will use zstd for compression. While part of the work will be done by spawning an external zstd process, this is the gem that will allow syskit-log to compress/decompress in-process.