### PR TITLE
Remove hard coded osg_qt* dependency for gui/vizkit3d

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -9,7 +9,6 @@ in_flavor 'master', 'stable' do
     ruby_package 'gui/vizkit'
 
     cmake_package 'gui/vizkit3d' do |pkg|
-        pkg.depends_on "gui/osg_qt4"
         if manifest.package_enabled?('rtt', false) # the toolchain is built, add it to the rtt_target
             pkg.define "OROCOS_TARGET", Autoproj.config.get('rtt_target')
         end


### PR DESCRIPTION
This removes the gui/osg_qt4 dependency of gui/vizkit3d that is added in the 04stable.autobuild file. The manifest.xml of gui/vizkit3d has carried this dependency now for quite some time, so lets remove it here.