### PR TITLE
feat: create a config flag to disable JUnit output

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -63,7 +63,7 @@ Autoproj.manifest.each_autobuild_package do |pkg|
         end
     end
 
-    if pkg.kind_of?(Autobuild::Ruby)
+    if pkg.kind_of?(Autobuild::Ruby) && Autoproj.config.get("test_junit_output", true)
         pkg.post_import do
             if pkg.test_utility.enabled?
                 pkg.depends_on "minitest-junit"
@@ -82,7 +82,7 @@ Autoproj.manifest.each_autobuild_package do |pkg|
 
             # Augment autoproj's autodetection of test tasks to handle
             # bindings/ruby
-            unless pkg.test_utility.source_dir
+            unless pkg.test_utility.source_dir && Autoproj.config.get("test_junit_output", true)
                 ruby_test_dir = File.join(pkg.srcdir, 'bindings', 'ruby', 'test')
                 if File.directory?(ruby_test_dir)
                     pkg.test_utility.source_dir =


### PR DESCRIPTION
Was a good experiment, but never went anywhere. Allow disabling it when not needed.