### PR TITLE
Add gui/qtpropertybrowser for gui/vizkit3d

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -217,6 +217,8 @@ in_flavor 'master', 'stable' do
         pkg.env_add_path 'QT_PLUGIN_PATH', File.join(pkg.prefix, "lib", "qt")
     end
 
+    cmake_package 'gui/qtpropertybrowser'
+
     ##### Base implementation for data acquisition
     cmake_package 'drivers/iodrivers_base'
     orogen_package 'drivers/orogen/iodrivers_base'

--- a/source.yml
+++ b/source.yml
@@ -42,6 +42,10 @@ version_control:
     - gui/.*:
       github: rock-core/gui-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH
+
+    - gui/qtpropertybrowser:
+      github: abhijitkundu/QtPropertyBrowser
+
     - drivers/orogen/.*:
       github: rock-core/drivers-orogen-$PACKAGE_BASENAME
       branch: $ROCK_BRANCH


### PR DESCRIPTION
This is included in gui/vizkit3d for qt4, but was externalised for qt5.