### PR TITLE
feat: declare base/ruby_eigen

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -33,3 +33,6 @@ end
 
 cmake_package "gui/osg_qt4"
 remove_from_default "gui/osg_qt4"
+
+ruby_package "base/ruby_eigen"
+remove_from_default "base/ruby_eigen"


### PR DESCRIPTION
It is an extracted version of the Eigen Ruby bindings that are currently in base/types. The objective is to have them ready to use when needed to test the migration

Separating them in a different package helps other Ruby packages that do not depend on base/types in any way, but do use Eigen types (e.g. sdformat, transformer)