### PR TITLE
chore: add yaml osdep to irb gem

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -384,5 +384,13 @@ grpc-ruby-tools:
 valgrind:
     debian,ubuntu: valgrind
 
+yaml:
+    debian,ubuntu: libyaml-dev
+    gentoo: dev-libs/libyaml
+    fedora,opensuse: libyaml-devel
+    arch,manjarolinux: libyaml
+
 irb:
   gem: irb
+  osdep:
+    - yaml


### PR DESCRIPTION
https://github.com/rock-core/package_set/pull/242/ adds irb gem but it needs libyaml-dev 