### PR TITLE
Osdeps qwt5 osg_qt4

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -124,6 +124,7 @@ gui/osg_qt4:
     ubuntu:
         '16.04,18.04,18.10,19.04,19.10':
             osdep: osg
+        default: nonexistent
 
 qt4:
     # QMake is needed for the CMake macro for Qt4

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -81,7 +81,7 @@ rice:
 qwt5:
     debian,ubuntu:
         default: libqwt5-qt4-dev
-        '20.04,22.04': nonexistent
+        '20.04,22.04,24.04': nonexistent
     fedora,opensuse: qwt-devel
     darwin: qwt
     arch: qwt5


### PR DESCRIPTION
Mark qwt5 and osg_qt4 non-existent on more platforms