### PR TITLE
chore: remove base/templates/bundles from rock.core

### DIFF
--- a/04stable.autobuild
+++ b/04stable.autobuild
@@ -76,6 +76,7 @@ in_flavor 'master', 'stable' do
     import_package 'base/templates/cmake_vizkit_widget'
     import_package 'base/templates/vizkit3d_plugin'
     import_package 'base/templates/bundle'
+    remove_from_default "base/templates/bundle"
     import_package 'base/templates/doc'
 
     # Setup bundle support only if base/scripts is enabled 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/base-scripts/pull/44

The rock-create-bundle now points to manual step-by-step from the rock&syskit documentation on how to create a bundle.

The template is obsolete, and difficult to keep in lockstep with the canonical way to create syskit app, that is `syskit gen`