### PR TITLE
fix: add qt4-related definitions for Ubuntu 24.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -255,10 +255,12 @@ qtruby:
         "16.04,18.04":
             gem: qtbindings
             osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
-        "24.04": ignore
-        default:
+        "20.04":
             gem: rock-qtbindings
             osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
+        "24.04":
+            gem: rock-qtbindings
+            osdep: [qt4, qt4-opengl, qt-designer, ruby-dev, cmake]
     gentoo:
         kde-base/kdebindings-ruby
 

--- a/rock.osrepos
+++ b/rock.osrepos
@@ -5,3 +5,9 @@
         - type: key
           keyserver: hkp://keyserver.ubuntu.com:80
           id: 63BBCC76C6D55B7DF2D65B2A78CB407D3E3D8F94
+    - noble:
+        - type: repo
+          repo: deb http://ppa.launchpad.net/rock-core/qt4/ubuntu noble main
+        - type: key
+          keyserver: hkp://keyserver.ubuntu.com:80
+          id: 63BBCC76C6D55B7DF2D65B2A78CB407D3E3D8F94


### PR DESCRIPTION
I could not get to build webkit, so removed it from the list (and will remove its usage in the ruby toolchain ...)