### PR TITLE
chore: use our fork of aruba instead of the gem

### DIFF
--- a/00new_packages.autobuild
+++ b/00new_packages.autobuild
@@ -36,3 +36,12 @@ remove_from_default "gui/osg_qt4"
 
 ruby_package "base/ruby_eigen"
 remove_from_default "base/ruby_eigen"
+
+ruby_package "tools/aruba" do |pkg|
+    pkg.rake_setup_task = nil
+    pkg.test_utility.available = false
+
+    pkg.depends_on "contracts"
+end
+
+Autoproj.add_osdeps_overrides "aruba", package: "tools/aruba", force: true

--- a/init.rb
+++ b/init.rb
@@ -38,7 +38,7 @@ if rubocop_gemfile
 end
 Autoproj.env.set "RUBOCOP_CMD", "rubocop-manager"
 
-# Ruby 1.8 is completly outdated, if you modify this, take respect to the addition checks below against 1.9 
+# Ruby 1.8 is completly outdated, if you modify this, take respect to the addition checks below against 1.9
 if defined?(RUBY_VERSION) && (RUBY_VERSION =~ /^1\.8\./)
     Autoproj.error "Ruby 1.8 is not supported by Rock anymore"
     Autoproj.error ""
@@ -82,7 +82,7 @@ current_flavor = Rock.flavors.current_flavor
 
 #This check is needed because the overrides file will override the FLAVOR selection.
 #Furthermore a selection != stable can cause a inconsistent layout (cause by in_flavor system in the package_sets)
-if Rock.in_release? && current_flavor.branch != "stable" 
+if Rock.in_release? && current_flavor.branch != "stable"
     if ENV['ROCK_RC'] == '1'
         Autoproj.warn ""
         Autoproj.warn "Found a release file and the flavor is not master"
@@ -203,3 +203,7 @@ if (sanitizers = Autoproj.config.get("cxx_sanitizers", nil))
     end
 end
 
+Autoproj.env_set(
+    "ROCK_RTT_BUILTIN_TYPEKIT",
+    Autoproj.config.get("rtt_builtin_typekit", true) ? "1" : "0"
+)

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -398,3 +398,5 @@ irb:
   gem: irb
   osdep:
     - yaml
+
+contracts: gem

--- a/source.yml
+++ b/source.yml
@@ -94,6 +94,10 @@ version_control:
       github: msgpack/msgpack-c
       tag: cpp-3.1.1
 
+    - tools/aruba:
+        github: rock-core/aruba
+        branch: forwarded_ios-2.2.0
+
 overrides:
     - ^(orogen|typelib|rtt|utilrb|utilmm|rtt_typelib|tools/metaruby)$:
       branch: $ROCK_BRANCH


### PR DESCRIPTION
Aruba does not support (yet) passing file descriptors to the subcommands, which is a feature that both Roby and Syskit desesperately need ...